### PR TITLE
create folder fl.configURI + 'Commands/xJSFL/' if not exists

### DIFF
--- a/core/jsfl/install/install.jsfl
+++ b/core/jsfl/install/install.jsfl
@@ -145,10 +145,18 @@
 		
 			// remove old commands
 				xjsfl.output.trace('removing old commands...', true);
-				var uris			= Utils.getURIs(fl.configURI + 'Commands/xJSFL/');
-				for each(var uri in uris)
+				var commandsFolder = fl.configURI + 'Commands/xJSFL/';
+				if (FLfile.exists(commandsFolder))
 				{
-					remove(uri);
+					var uris			= Utils.getURIs(commandsFolder);
+					for each(var uri in uris)
+					{
+						remove(uri);
+					}
+				}
+				else
+				{
+					FLfile.createFolder(commandsFolder);
 				}
 				
 			// debug


### PR DESCRIPTION
1. exception thrown when folder not exists.
2. for Flash CS4, it will generate a strange message help when no fla opened. The message is not helpful at all, actually misleading. It a bug of Flash CS4, but it's better to check the folder's existence.
