### PR TITLE
iterator fix

### DIFF
--- a/core/jsfl/libraries/flash/Iterators.jsfl
+++ b/core/jsfl/libraries/flash/Iterators.jsfl
@@ -140,7 +140,7 @@
 						//trace('Item:' + i);
 
 					// skip if item doens't have a timeline
-						if( ! items[i]['timeline'] )
+						if( !('timeline' in items[i]) )
 							continue
 
 					// context


### PR DESCRIPTION
fixed error for iterators over library with fonts (exception was thrown on access of 'timeline' property)
