### PR TITLE
added 'font' in the pseudo type list

### DIFF
--- a/core/jsfl/libraries/elements/Selectors.jsfl
+++ b/core/jsfl/libraries/elements/Selectors.jsfl
@@ -266,7 +266,7 @@
 										var name = exec[8];
 										
 									// type
-										if(/instance|symbol|bitmap|sound|embeddedvideo|linkedvideo|video|compiledclip|text|folder|static|dynamic|input|primitive|group|shape|movieclip|graphic|button/.test(name))
+										if(/instance|symbol|bitmap|sound|embeddedvideo|linkedvideo|video|compiledclip|text|folder|static|dynamic|input|primitive|group|shape|movieclip|graphic|button|font/.test(name))
 										{
 											selector.type	= 'type';
 											selector.params	= [null, name];


### PR DESCRIPTION
The documentation states that $$(":font") is a valid selector, but using that throws an error. This fixes that so that everything works fine.
