### PR TITLE
Fixing Regex issue which fixes functionality for Adobe Animate

### DIFF
--- a/core/jsfl/libraries/objects/XML.jsfl
+++ b/core/jsfl/libraries/objects/XML.jsfl
@@ -37,7 +37,7 @@
 		 * @type {RegExp}	type, attr, operator, value
 		 * @ignore
 		 */
-		var rxFilter		= /([@#\.])([\w_-:]+)([\^\$!=<>]+)?([^"'\(\)]+)?/;
+		var rxFilter		= /([@#\.])([\w:-_]+)([\^\$!=<>]+)?([^"'\(\)]+)?/;
 		
 		/**
 		 * 


### PR DESCRIPTION
Updated _rxFilter_ regex which had a ‘character range is out of order’ issue.  Users were experiencing an error on link 733 in file "xjsfl.jsfl" when the xml.js was being loaded, then XML parsing was failing downstream after error dialog box was closed.

Verified in Adobe Animate that xJSFL tool installs correctly.

Resolves #7 